### PR TITLE
Fix systemd-sysext unrecognized option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ just sysext
 ```
 
 This will create a system-extension inside `cosmic-sysext`, that you can move (without renaming!) into e.g. `/var/lib/extensions`.
-After starting systemd-sysext.service (`sudo systemctl enable --now systemd-sysext`) and refreshing (`sudo systemd-sysext --refresh`) or rebooting
+After starting systemd-sysext.service (`sudo systemctl enable --now systemd-sysext`) and refreshing (`sudo systemd-sysext refresh`) or rebooting
 *COSMIC* will be an available option in your favorite display manager.
 
 **Note**: An extension created this way will be linked against specific libraries on your system and will not work on other distributions.


### PR DESCRIPTION
When trying to use `systemd-sysext --refresh` the following error is encountered:

`systemd-sysext: unrecognized option '--refresh'`

This PR fixes that.