### PR TITLE
docs: Remove obsolete cosmic-applet-host from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Currently an incomplete **pre-alpha**.
 
 ## Components of COSMIC Desktop
 * [cosmic-applets](https://github.com/pop-os/cosmic-applets)
-* [cosmic-applet-host](https://github.com/pop-os/cosmic-applet-host)
 * [cosmic-applibrary](https://github.com/pop-os/cosmic-applibrary)
 * [cosmic-comp](https://github.com/pop-os/cosmic-comp)
 * [xdg-desktop-portal-cosmic](https://github.com/pop-os/xdg-desktop-portal-cosmic)


### PR DESCRIPTION
cosmic-applet-host was superseded by `iced-sctk` and was removed from COSMIC in https://github.com/pop-os/cosmic-epoch/commit/d239cc0146b99f6c676a49a604805f4b82caf904.