### PR TITLE
Adds a note about "Read-only filesystem" when testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ After starting systemd-sysext.service (`sudo systemctl enable --now systemd-syse
 It also requires the previously mentioned libraries/dependencies at runtime to be installed in your system (the system extension does not carry these libraries).
 
 **Read-Only Filesystem**: If you're not on an immutable distro you may notice that `/usr/` and `/opt/` are read-only.
-this is caused by `systemd-sysext` being enabled, when you are done testing you can disable `systemd-sysext` (`sudo systemctl disable systemd-sysext`)
+this is caused by `systemd-sysext` being enabled, when you are done testing you can disable `systemd-sysext` (`sudo systemctl disable --now systemd-sysext`)
 
 It is thus no proper method for long term deployment.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ After starting systemd-sysext.service (`sudo systemctl enable --now systemd-syse
 **Note**: An extension created this way will be linked against specific libraries on your system and will not work on other distributions.
 It also requires the previously mentioned libraries/dependencies at runtime to be installed in your system (the system extension does not carry these libraries).
 
+**Read-Only Filesystem**: If you're not on an immutable distro you may notice that `/usr/` and `/opt/` are read-only.
+this is caused by `systemd-sysext` being enabled, when you are done testing you can disable `systemd-sysext` (`sudo systemctl disable systemd-sysext`)
+
 It is thus no proper method for long term deployment.
 
 ### Packaging


### PR DESCRIPTION
This PR updates the README to add a note on a "Read-only Filesystem" error after enabling `systemd-sysext`

related issue: #138 