### PR TITLE
feat: add cosmic-files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -74,3 +74,7 @@
 [submodule "cosmic-randr"]
 	path = cosmic-randr
 	url = https://github.com/pop-os/cosmic-randr.git
+[submodule "cosmic-files"]
+	path = cosmic-files
+	url = https://github.com/pop-os/cosmic-files.git
+	branch = master_jammy

--- a/README.md
+++ b/README.md
@@ -7,24 +7,28 @@ Currently an incomplete **pre-alpha**. Testing instructions below for various di
 * [cosmic-applets](https://github.com/pop-os/cosmic-applets)
 * [cosmic-applibrary](https://github.com/pop-os/cosmic-applibrary)
 * [cosmic-comp](https://github.com/pop-os/cosmic-comp)
+* [cosmic-edit](https://github.com/pop-os/cosmic-edit)
+* [cosmic-files](https://github.com/pop-os/cosmic-files)
 * [cosmic-launcher](https://github.com/pop-os/cosmic-launcher)
 * [cosmic-notifications](https://github.com/pop-os/cosmic-notifications)
 * [cosmic-osd](https://github.com/pop-os/cosmic-osd)
 * [cosmic-panel](https://github.com/pop-os/cosmic-panel)
-* [cosmic-protocols](https://github.com/pop-os/cosmic-protocols)
 * [cosmic-randr](https://github.com/pop-os/cosmic-randr)
-* [cosmic-settings](https://github.com/pop-os/cosmic-settings)
-* [cosmic-settings-daemon](https://github.com/pop-os/cosmic-settings-daemon)
 * [cosmic-session](https://github.com/pop-os/cosmic-session)
-* [cosmic-text](https://github.com/pop-os/cosmic-text)
-* [cosmic-edit](https://github.com/pop-os/cosmic-edit)
+* [cosmic-settings-daemon](https://github.com/pop-os/cosmic-settings-daemon)
+* [cosmic-settings](https://github.com/pop-os/cosmic-settings)
 * [cosmic-term](https://github.com/pop-os/cosmic-term)
-* [cosmic-theme](https://github.com/pop-os/cosmic-theme)
 * [cosmic-theme-editor](https://github.com/pop-os/cosmic-theme-editor)
-* [cosmic-time](https://github.com/pop-os/cosmic-time)
 * [cosmic-workspaces-epoch](https://github.com/pop-os/cosmic-workspaces-epoch)
-* [libcosmic](https://github.com/pop-os/libcosmic)
 * [xdg-desktop-portal-cosmic](https://github.com/pop-os/xdg-desktop-portal-cosmic)
+
+### COSMIC libraries/crates
+
+* [cosmic-protocols](https://github.com/pop-os/cosmic-protocols)
+* [cosmic-text](https://github.com/pop-os/cosmic-text)
+* [cosmic-theme](https://github.com/pop-os/cosmic-theme)
+* [cosmic-time](https://github.com/pop-os/cosmic-time)
+* [libcosmic](https://github.com/pop-os/libcosmic)
 
 ## Setup on distributions without packaging of cosmic components
 

--- a/justfile
+++ b/justfile
@@ -9,6 +9,7 @@ build:
     {{ just }} cosmic-bg/build-release
     {{ make }} -C cosmic-comp all
     {{ just }} cosmic-edit/build-release
+    {{ just }} cosmic-files/build-release
     {{ just }} cosmic-greeter/build-release
     {{ just }} cosmic-launcher/build-release
     {{ just }} cosmic-notifications/build-release
@@ -30,6 +31,7 @@ sysext dir=`echo $(pwd)/cosmic-sysext` version=("nightly-" + `git rev-parse --sh
     {{ just }} rootdir={{dir}} cosmic-bg/install
     {{ make }} -C cosmic-comp install DESTDIR={{dir}}
     {{ just }} rootdir={{dir}} cosmic-edit/install
+    {{ just }} rootdir={{dir}} cosmic-files/install
     {{ just }} rootdir={{dir}} cosmic-greeter/install
     {{ just }} rootdir={{dir}} cosmic-icons/install
     {{ just }} rootdir={{dir}} cosmic-launcher/install
@@ -62,6 +64,7 @@ clean:
     rm -rf cosmic-bg/target
     rm -rf cosmic-comp/target
     rm -rf cosmic-edit/target
+    {{ just }} cosmic-files/clean
     rm -rf cosmic-greeter/target
     rm -rf cosmic-launcher/target
     rm -rf cosmic-panel/target


### PR DESCRIPTION
- add cosmic-files submodule reference
- add cosmic-files to README.md (and subjectively tidy/sort listing of COSMIC projects)
- add cosmic-files to `just`
- confirm `cosmic sysext` works and result includes a working `cosmic-files` executable