### PR TITLE
Allow rootdir and prefix to be modified for `just install`

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,6 +2,9 @@ set dotenv-load
 just := just_executable()
 make := `which make`
 
+rootdir := ''
+prefix := '/usr/local'
+
 build:
     mkdir -p build
     {{ just }} cosmic-applets/build-release
@@ -25,7 +28,8 @@ build:
     {{ make }} -C cosmic-workspaces-epoch all
     {{ make }} -C xdg-desktop-portal-cosmic all
 
-install rootdir="" prefix="/usr/local": build
+install:
+    build
     {{ just }} rootdir={{rootdir}} prefix={{prefix}} cosmic-applets/install
     {{ just }} rootdir={{rootdir}} prefix={{prefix}} cosmic-applibrary/install
     {{ just }} rootdir={{rootdir}} prefix={{prefix}} cosmic-bg/install


### PR DESCRIPTION
I think these are the changes necessary to allow rootdir and prefix to be changed when running `just install`

Without this PR, when I try to run `just rootdir=/build install` the following error occurs:

    error: Variable `rootdir` overridden on the command line but not present in justfile

This is necessary for my custom build artifacts of COSMIC, which I'm currently using for my atomic images