### PR TITLE
add another apt command for installing cosmic

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ sudo systemctl restart gdm
 ```
 
 #### Install COSMIC
-`sudo apt install cosmic-*`
+`sudo apt install cosmic-*` or `sudo apt install '~ncosmic-.*'`
 
 After logging out, click on your user and there will be a sprocket at the bottom right. Change the setting to COSMIC. Proceed to log in.
 


### PR DESCRIPTION
In the recent versions of apt the below command is not working `sudo apt install cosmic-*`
It needs to be like that
`sudo apt install '~ncosmic-.*'`

resources: 
https://askubuntu.com/questions/1218814/problem-using-wildcard-with-apt