### PR TITLE
Update Arch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ After logging out, click on your user and there will be a sprocket at the bottom
 
 ## Installing on Arch Linux
 Installing via the preferred AUR helper is possible the usual way, e.g.:
-`paru -S cosmic-epoch-git`
+`paru -S cosmic-session-git`
 
 Then log out, click on your user, and a sprocket at the bottom right shows an additional entry alongside your desktop environments. Change to COSMIC and proceed with log in.
 For a more detailed discussion, consider the [relevant section in the Arch wiki](https://wiki.archlinux.org/title/COSMIC).


### PR DESCRIPTION
The `cosmic-epoch-git` AUR package has been deleted. Users should install [`cosmic-session-git`](https://aur.archlinux.org/packages/cosmic-session-git)instead.