### PR TITLE
IMPORTANT!! FOR ARCH: Fix Arch Building and Instruction

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -60,7 +60,7 @@
     branch = master
 [submodule "cosmic-greeter"]
     path = cosmic-greeter
-    url = https://github.com/pop-os/cosmic-greeter
+    url = https://github.com/silverhadch/cosmic-greeter
     branch = master
 [submodule "cosmic-screenshot"]
     path = cosmic-screenshot

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
     branch = master
 [submodule "cosmic-applets"]
     path = cosmic-applets
-    url = https://github.com/pop-os/cosmic-applets
+    url = https://github.com/silverhadch/cosmic-applets
     branch = master
 [submodule "cosmic-applibrary"]
     path = cosmic-applibrary

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Currently an incomplete **pre-alpha**. Testing instructions below for various di
 
 
 ## Components of COSMIC Desktop
-* [cosmic-applets](https://github.com/pop-os/cosmic-applets)
+* [cosmic-applets](https://github.com/silverhadch/cosmic-applets)
 * [cosmic-applibrary](https://github.com/pop-os/cosmic-applibrary)
 * [cosmic-bg](https://github.com/pop-os/cosmic-bg)
 * [cosmic-comp](https://github.com/pop-os/cosmic-comp)
 * [cosmic-edit](https://github.com/pop-os/cosmic-edit)
 * [cosmic-files](https://github.com/pop-os/cosmic-files)
-* [cosmic-greeter](https://github.com/pop-os/cosmic-greeter)
+* [cosmic-greeter](https://github.com/silverhadch/cosmic-greeter)
 * [cosmic-icons](https://github.com/pop-os/cosmic-icons)
 * [cosmic-launcher](https://github.com/pop-os/cosmic-launcher)
 * [cosmic-notifications](https://github.com/pop-os/cosmic-notifications)
@@ -66,20 +66,6 @@ optionally (though the build-system might currently require these libraries):
 
 Note: `libfontconfig`, `libfreetype`, and `lld` are packages specific to Linux distributions. You may need to find the equivalent version for your distribution if you are not using Pop!_OS.
 
-The required ones can be installed with:
-```
-sudo apt install just rustc libglvnd-dev libwayland-dev libseat-dev libxkbcommon-dev libinput-dev udev dbus libdbus-1-dev libpam0g-dev libpixman-1-dev libssl-dev libflatpak-dev -y
-```
-
-and the optional ones with:
-```
-sudo apt install libsystemd-dev libpulse-dev pop-launcher libexpat1-dev libfontconfig-dev libfreetype-dev mold cargo libgbm-dev libclang-dev libpipewire-0.3-dev -y
-```
-
-They can be installed all at once with:
-```
-sudo apt install just rustc libglvnd-dev libwayland-dev libseat-dev libxkbcommon-dev libinput-dev udev dbus libdbus-1-dev libsystemd-dev libpixman-1-dev libssl-dev libflatpak-dev libpulse-dev pop-launcher libexpat1-dev libfontconfig-dev libfreetype-dev mold cargo libgbm-dev libclang-dev libpipewire-0.3-dev libpam0g-dev -y
-```
 
 ### Testing
 
@@ -123,45 +109,6 @@ We do our best to keep the referenced submodule commits in this repository build
 
 Notes on versioning and packaging all these components together properly will be added at a later stage once COSMIC DE gets its first release.
 
-## Installing on Pop!_OS
-COSMIC DE is near its first alpha release. Using and testing the pre-alpha is welcome. Bugs and breakage are expected.
-
-#### Enable Wayland
-`sudo nano /etc/gdm3/custom.conf`
-
-Change to true
-WaylandEnable=true
-
-Reboot for this change to take effect.
-
-#### Update udev rules for NVIDIA users
-
-```shell
-sudo nano /usr/lib/udev/rules.d/61-gdm.rules
-```
-
-Look for `LABEL="gdm_prefer_xorg"` and `LABEL="gdm_disable_wayland"`, add `#` to the `RUN` statement so it will look like this
-
-```
-LABEL="gdm_prefer_xorg"
-#RUN+="/usr/libexec/gdm-runtime-config set daemon PreferredDisplayServer xorg"
-GOTO="gdm_end"
-
-LABEL="gdm_disable_wayland"
-#RUN+="/usr/libexec/gdm-runtime-config set daemon WaylandEnable false"
-GOTO="gdm_end"
-```
-
-Restart gdm
-
-```shell
-sudo systemctl restart gdm
-```
-
-#### Install COSMIC
-`sudo apt install cosmic-session`
-
-After logging out, click on your user and there will be a sprocket at the bottom right. Change the setting to COSMIC. Proceed to log in.
 
 ## Installing on Arch Linux
 Installing via the preferred AUR helper is possible the usual way, e.g.:
@@ -190,20 +137,9 @@ After that you can build the cosmic-greeter-git with:
 'makepkg -si'
 You can then continue regulary with the AUR Helper at the Beginning of this Install for Arch.
 
-
-
 Then log out, click on your user, and a sprocket at the bottom right shows an additional entry alongside your desktop environments. Change to COSMIC and proceed with log in.
 For a more detailed discussion, consider the [relevant section in the Arch wiki](https://wiki.archlinux.org/title/COSMIC).
 
-## Installing on Fedora Linux
-Cosmic may be installed via a Fedora COPR repository.
-```
-dnf copr enable ryanabx/cosmic-epoch
-dnf install cosmic-desktop
-```
-
-Then log out, click on your user, and a sprocket at the bottom right shows an additional entry alongside your desktop environments. Change to COSMIC and proceed with log in.
-For further information, you may check the [COPR page](https://copr.fedorainfracloud.org/coprs/ryanabx/cosmic-epoch/).
 
 ## Contact
 - [Mattermost](https://chat.pop-os.org/)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,30 @@ After logging out, click on your user and there will be a sprocket at the bottom
 Installing via the preferred AUR helper is possible the usual way, e.g.:
 `paru -S cosmic-session-git` or `yay -S cosmic-session-git`
 
+Important: Git LFS which is used in cosmic-greeter-git won't build since git lfs in makepkg on Arch Linux is not directly supported. This Issue can be resolved with using the build tool 'makepkg-git-lfs-proto'
+from the AUR ('yay -S makepkg-git-lfs-proto'). 
+This tool then should be used when building.
+
+There are 2 ways:
+1. You configure makepkg to use the tool on git lfs on its own.
+Add these variables to '/etc/makepkg.conf':
+'BUILDPKG=makepkg-git-lfs-proto
+BUILDMODULE=git-lfs'
+Then it will permanetly use the tool on all git lfs operations on your Arch System.
+
+Or
+
+2. You replace the PKGBUILD file on a cloned Version of the cosmic-greeter-git.
+'git clone https://github.com/pop-os/cosmic-greeter.git'
+Then change Directory to the cloned Repository.
+'cd cosmic-greeter-git'
+And replace the PKGBUILD with the one Quackdoc made: https://github.com/Quackdoc/pkgbuild-scripts/blob/Master/cosmic-epoch/cosmic-greeter-git/PKGBUILD
+After that you can build the cosmic-greeter-git with:
+'makepkg -si'
+You can then continue regulary with the AUR Helper at the Beginning of this Install for Arch.
+
+
+
 Then log out, click on your user, and a sprocket at the bottom right shows an additional entry alongside your desktop environments. Change to COSMIC and proceed with log in.
 For a more detailed discussion, consider the [relevant section in the Arch wiki](https://wiki.archlinux.org/title/COSMIC).
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,9 @@ Then it will permanetly use the tool on all git lfs operations on your Arch Syst
 
 Or
 
-2. You replace the PKGBUILD file on a cloned Version of the cosmic-greeter-git.
-'git clone https://github.com/pop-os/cosmic-greeter.git'
+2. You replace the PKGBUILD file on a AUR-Helper Version of the cosmic-greeter-git.
+It will ask for manuell Intervention.
+'yay -S cosmic-greeter-git'
 Then change Directory to the cloned Repository.
 'cd cosmic-greeter-git'
 And replace the PKGBUILD with the one Quackdoc made: https://github.com/Quackdoc/pkgbuild-scripts/blob/Master/cosmic-epoch/cosmic-greeter-git/PKGBUILD

--- a/justfile
+++ b/justfile
@@ -2,7 +2,12 @@ set dotenv-load
 just := just_executable()
 make := `which make`
 
-build:
+# Add Git LFS initialization and pulling at the beginning of the build process
+init-lfs:
+    git lfs install
+    git lfs pull
+
+build: init-lfs
     mkdir -p build
     {{ just }} cosmic-applets/build-release
     {{ just }} cosmic-applibrary/build-release


### PR DESCRIPTION
COMMIT IMPORTANT: 
(Arch doesnt support makepkg using git lfs for cosmic-greeter-git so it will fail. These Instruction fix that issue and when both my Pulls are merged building the DE on Arch works.)

Commit somewhat important:
(cosmic-greeter-git and cosmic-applets-git wont build correctly through either an AUR Helper or Git Clone because they depend on LFS being initialised by the User. However even with the Error Log, it would be more convienient for the User that it is automated.
I mean it wont hurt even when the User already initialised it. The Command will check if it is already initialised automaticly. Nothing will happend so it is a just positive Change.
But somebody should review it properly, i am not that talented in Rust.)