### PR TITLE
Adding the correct Instructions and Fix for Arch build

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ There are 2 ways:
 You configure makepkg to use the tool on git lfs on its own. Add these variables to '/etc/makepkg.conf': 'BUILDPKG=makepkg-git-lfs-proto BUILDMODULE=git-lfs' Then it will permanetly use the tool on all git lfs operations on your Arch System.
 Or
 
-You replace the PKGBUILD file on a AUR-Helper Version of the cosmic-greeter-git. It will ask for manuell Intervention. 'yay -S cosmic-greeter-git' Then change Directory to the cloned Repository. 'cd cosmic-greeter-git' And replace the PKGBUILD with the one Quackdoc made: https://github.com/Quackdoc/pkgbuild-scripts/blob/Master/cosmic-epoch/cosmic-greeter-git/PKGBUILD After that you can build the cosmic-greeter-git with: 'makepkg -si' You can then continue regulary with the AUR Helper at the Beginning of this Install for Arch.
+You replace the PKGBUILD file on a AUR-Helper Version of the cosmic-greeter-git. It will ask for manuell Intervention. 'yay -G cosmic-greeter-git' Then change Directory to the cloned Repository. 'cd cosmic-greeter-git' And replace the PKGBUILD with the one Quackdoc made: https://github.com/Quackdoc/pkgbuild-scripts/blob/Master/cosmic-epoch/cosmic-greeter-git/PKGBUILD After that you can build the cosmic-greeter-git with: 'makepkg -si' You can then continue regulary with the AUR Helper at the Beginning of this Install for Arch.
 
 
 Then log out, click on your user, and a sprocket at the bottom right shows an additional entry alongside your desktop environments. Change to COSMIC and proceed with log in.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ After logging out, click on your user and there will be a sprocket at the bottom
 
 ## Installing on Arch Linux
 Installing via the preferred AUR helper is possible the usual way, e.g.:
-`paru -S cosmic-session-git`
+`paru -S cosmic-session-git` or `yay -S cosmic-session-git`
 
 Then log out, click on your user, and a sprocket at the bottom right shows an additional entry alongside your desktop environments. Change to COSMIC and proceed with log in.
 For a more detailed discussion, consider the [relevant section in the Arch wiki](https://wiki.archlinux.org/title/COSMIC).

--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ After logging out, click on your user and there will be a sprocket at the bottom
 ## Installing on Arch Linux
 Installing via the preferred AUR helper is possible the usual way, e.g.:
 `paru -S cosmic-session-git` or `yay -S cosmic-session-git`
+Important: Git LFS which is used in cosmic-greeter-git won't build since git lfs in makepkg on Arch Linux is not directly supported. This Issue can be resolved with using the build tool 'makepkg-git-lfs-proto' from the AUR ('yay -S makepkg-git-lfs-proto'). This tool then should be used when building.
+
+There are 2 ways:
+
+You configure makepkg to use the tool on git lfs on its own. Add these variables to '/etc/makepkg.conf': 'BUILDPKG=makepkg-git-lfs-proto BUILDMODULE=git-lfs' Then it will permanetly use the tool on all git lfs operations on your Arch System.
+Or
+
+You replace the PKGBUILD file on a AUR-Helper Version of the cosmic-greeter-git. It will ask for manuell Intervention. 'yay -S cosmic-greeter-git' Then change Directory to the cloned Repository. 'cd cosmic-greeter-git' And replace the PKGBUILD with the one Quackdoc made: https://github.com/Quackdoc/pkgbuild-scripts/blob/Master/cosmic-epoch/cosmic-greeter-git/PKGBUILD After that you can build the cosmic-greeter-git with: 'makepkg -si' You can then continue regulary with the AUR Helper at the Beginning of this Install for Arch.
+
 
 Then log out, click on your user, and a sprocket at the bottom right shows an additional entry alongside your desktop environments. Change to COSMIC and proceed with log in.
 For a more detailed discussion, consider the [relevant section in the Arch wiki](https://wiki.archlinux.org/title/COSMIC).

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ sudo systemctl restart gdm
 After logging out, click on your user and there will be a sprocket at the bottom right. Change the setting to COSMIC. Proceed to log in.
 
 ## Installing on Arch Linux
+Git-lfs and an AUR-Helper is necessary. 
 Installing via the preferred AUR helper is possible the usual way, e.g.:
 `paru -S cosmic-session-git` or `yay -S cosmic-session-git`
 Important: Git LFS which is used in cosmic-greeter-git won't build since git lfs in makepkg on Arch Linux is not directly supported. This Issue can be resolved with using the build tool 'makepkg-git-lfs-proto' from the AUR ('yay -S makepkg-git-lfs-proto'). This tool then should be used when building.

--- a/justfile
+++ b/justfile
@@ -2,7 +2,12 @@ set dotenv-load
 just := just_executable()
 make := `which make`
 
-build:
+# Add Git LFS initialization and pulling at the beginning of the build process
+init-lfs:
+    git lfs install
+    git lfs pull
+
+build: init-lfs
     mkdir -p build
     {{ just }} cosmic-applets/build-release
     {{ just }} cosmic-applibrary/build-release


### PR DESCRIPTION
Git lfs doesnt work with makepkg on Archlinux. These Instructions should help. But i also made a Fork specific for Arch with detailed instruction and Changes so you might add my Fork fir installing Cosmic on Arch Linux. https://github.com/silverhadch/cosmic-epoch-archbuild