### PR TITLE
add libdisplay-info-dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ optionally (though the build-system might currently require these libraries):
 - libgbm-dev
 - libclang-dev
 - libpipewire-0.3-dev
+- libdisplay-info-dev
 
 Note: `libfontconfig`, `libfreetype`, and `lld` are packages specific to Linux distributions. You may need to find the equivalent version for your distribution if you are not using Pop!_OS.
 
@@ -75,12 +76,12 @@ sudo apt install just rustc libglvnd-dev libwayland-dev libseat-dev libxkbcommon
 
 and the optional ones with:
 ```
-sudo apt install libsystemd-dev libpulse-dev pop-launcher libexpat1-dev libfontconfig-dev libfreetype-dev mold cargo libgbm-dev libclang-dev libpipewire-0.3-dev -y
+sudo apt install libsystemd-dev libpulse-dev pop-launcher libexpat1-dev libfontconfig-dev libfreetype-dev mold cargo libgbm-dev libclang-dev libpipewire-0.3-dev libdisplay-info-dev -y
 ```
 
 They can be installed all at once with:
 ```
-sudo apt install just rustc libglvnd-dev libwayland-dev libseat-dev libxkbcommon-dev libinput-dev udev dbus libdbus-1-dev libsystemd-dev libpixman-1-dev libssl-dev libflatpak-dev libpulse-dev pop-launcher libexpat1-dev libfontconfig-dev libfreetype-dev mold cargo libgbm-dev libclang-dev libpipewire-0.3-dev libpam0g-dev -y
+sudo apt install just rustc libglvnd-dev libwayland-dev libseat-dev libxkbcommon-dev libinput-dev udev dbus libdbus-1-dev libsystemd-dev libpixman-1-dev libssl-dev libflatpak-dev libpulse-dev pop-launcher libexpat1-dev libfontconfig-dev libfreetype-dev mold cargo libgbm-dev libclang-dev libpipewire-0.3-dev libpam0g-dev libdisplay-info-dev -y
 ```
 
 ### Testing


### PR DESCRIPTION
Fixes #1788 

`libdisplay-info-dev` required for `cosmic-comp`