### PR TITLE
Add debian packaging helpers

### DIFF
--- a/scripts/pkg-deb-gitdev.sh
+++ b/scripts/pkg-deb-gitdev.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+vars() {
+    NAME=cosmic-desktop-git
+    DESC_SHORT="Cosmic Desktop"
+    VERSION=$(date +%Y%m%d)-$(git rev-parse --short HEAD)-1
+    ARCH=amd64
+    MAINTAINER="Nobody <nobody@localhost>"
+    DESC_LONG="${DESC_SHORT} from git"
+    PKG_FULL=${NAME}_${VERSION}_${ARCH}
+
+    BUILD_DIR=$(pwd)/_build/
+    export DESTDIR=${BUILD_DIR}/${PKG_FULL}
+}
+
+main() {
+    setup_dir_env
+    cd "${_SCRIPT_DIR}/.."
+    vars
+
+    echo "Version: ${VERSION}"
+    echo "DESTDIR: ${DESTDIR}"
+
+    rm -rf ${DESTDIR}
+    mkdir -p ${DESTDIR}/DEBIAN/
+
+    build
+    package_deb
+}
+
+setup_dir_env() {
+    _WORKING_DIR="$(pwd)"
+    local dir="$(dirname "${BASH_SOURCE[0]}")"
+    _SCRIPT_DIR="$(cd "$dir/" && pwd)"
+}
+
+build() {
+    just install ${DESTDIR} /usr
+}
+
+package_deb() {
+    cat <<-END >${DESTDIR}/DEBIAN/control
+Package: ${NAME}
+Version: ${VERSION}
+Architecture: ${ARCH}
+Maintainer: ${MAINTAINER}
+Description: ${DESC_SHORT}
+    ${DESC_LONG}
+END
+    dpkg-deb --build --root-owner-group ${DESTDIR}
+}
+
+main "$@"

--- a/scripts/pkg-debs.sh
+++ b/scripts/pkg-debs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+vars() {
+    REPO_DIR="$(pwd)"
+    BUILD_DIR="${BUILD_DIR:-${REPO_DIR}}/_build/debs_$(date +%s)"
+    PROJECTS=()
+    export JOBS="${JOBS:-$(nproc)}"
+    export DEB_BUILD_OPTIONS="parallel=${JOBS}"
+}
+
+main() {
+    setup_dir_env
+    cd "${_SCRIPT_DIR}/.."
+    vars
+
+    echo "BUILD_DIR: ${BUILD_DIR}"
+    echo "JOBS: ${JOBS}"
+
+    rm -rf "${BUILD_DIR}"
+    mkdir -p "${BUILD_DIR}"
+
+    discover_projects
+    build_projects
+}
+
+setup_dir_env() {
+    _WORKING_DIR="$(pwd)"
+    local dir="$(dirname "${BASH_SOURCE[0]}")"
+    _SCRIPT_DIR="$(cd "$dir/" && pwd)"
+}
+
+discover_projects() {
+  echo "=== Discovering debian subprojects.."
+  mapfile -t PROJECTS < <(
+    cd "$REPO_DIR"
+    find . -maxdepth 2 -type d -name debian -printf '%h\n' | sed 's|^\./||' | sort
+  )
+  [ "${#PROJECTS[@]}" -gt 0 ] || { echo "No debian/ directories found"; exit 1; }
+  for p in "${PROJECTS[@]}"; do echo " - $p"; done
+}
+
+build_projects() {
+  for p in "${PROJECTS[@]}"; do
+    echo "=== Building: $p"
+    pushd "$REPO_DIR/$p" >/dev/null
+    dpkg_build
+    popd >/dev/null
+    mv -f *.deb *.buildinfo *.changes "$BUILD_DIR" || true
+  done
+}
+
+dpkg_build() {
+    sudo mk-build-deps -i -r debian/control || true
+    dpkg-buildpackage -b -d -uc -us -j"${JOBS}"
+}
+
+main "$@"


### PR DESCRIPTION
## Context

- Currently, there's no way to quickly generate a debian package for all packages in one-go for quick development. 
- This PR adds a script that builds all the packages given that the dependencies are already there and installed in the system. 
- Note that this does NOT add the project chain of dependencies and will never be a replacement for a proper debian package build that iterates through each of the packages and builds all of them as individual packages. 
- However, this makes it much much easier on development machines or for people who wish to build from git and already have all the dependencies quickly build a single package that includes all and quickly deploy it without having to use systemd sysext (which requires parts of the fs tree to be immutable) or having to do a manual install. 

## Example usage

```
./scripts/pkg-deb-gitdev.sh
dpkg -i ./_build/<pkg>.deb
```

That's it. Just simply running the script will automatically run `just build` and build a single debian package in the `_build` dir that's ready to be installed with dpkg. 