### PR TITLE
Fix: just build due to cosmic-initial-setup

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ build:
     {{ just }} cosmic-files/build-release
     {{ just }} cosmic-greeter/build-release
     {{ just }} cosmic-idle/build-release
-    {{ just }} cosmic-initial-setup/build-release
+    {{ just }} cosmic-initial-setup/default
     {{ just }} cosmic-launcher/build-release
     {{ just }} cosmic-notifications/build-release
     {{ make }} -C cosmic-osd all


### PR DESCRIPTION
- Seems cosmic-initial-setup broke the `just build` from the root again
- It's due to build-release target not available. 
- Better fix it likely to be targeted at cosmic-initial-setup to apply these rules to be consistent with the other packages again. However, this currently fixes running `just` overall by using the default target which in turns runs `build-release`.  